### PR TITLE
Use service to restart auditd

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,10 +13,9 @@
   when:
     - ansible_connection not in [ "container", "docker", "community.docker.docker" ]
 
-- name: Restart auditd
-  ansible.builtin.service:
-    name: "{{ auditd_service }}"
-    state: restarted
-    use: service
+# systemctl can't restart auditd, service can: https://access.redhat.com/solutions/2664811
+- name: Restart auditd  # noqa: command-instead-of-module
+  ansible.builtin.command:
+    cmd: /usr/sbin/service {{ auditd_service }} restart
   when:
     - not ansible_check_mode


### PR DESCRIPTION
---
name: Pull request
about: Resolve issue #18 

---

**Describe the change**
Rewrite of handler `restart auditd` to use the `/usr/sbin/service` command instead of the `ansible.builtin.service` module. This ensures `auditd` is restarted properly, for example in the event of a configuration change.

See issue #18 for more in depth information.

**Testing**
First I tested this for my situation. This fixes my issue. Per my playbook in issue #18 : I want to set the `log_group` to group `splunk` and a restart of `auditd` should modify the group ownership of the `audit.log` file.

```
# ### before Ansible Playbook run
# ls -lh /var/log/audit/
total 14M
-rw-------. 1 root root 5,2M Jan 10 11:23 audit.log
-r--------. 1 root root 8,1M Jan  6 21:38 audit.log.1
# ### after Ansible Playbook run, with this fix applied to the role
[root@sibvsurheltest ~]# ls -lh /var/log/audit/
total 14M
-rw-r-----. 1 root splunk 5,5M Jan 10 11:26 audit.log
-r--r-----. 1 root root   8,1M Jan  6 21:38 audit.log.1
# systemctl status auditd.service | grep -i active
   Active: active (running) since Tue 2023-01-10 11:33:41 CET; 12s ago
```

This role specifies compatibility with:

- (RH)EL 8
- Debian
- Fedora
- OpenSUSE
- Ubuntu

I verified the location of the `/usr/sbin/service` script in, the most recent, version of each of them:

### RHEL 8
```
# grep PRETTY_NAME /etc/os-release && ls -l /usr/sbin/service
PRETTY_NAME="Red Hat Enterprise Linux 8.7 (Ootpa)"
-rwxr-xr-x. 1 root root 3729 Aug 10 15:03 /usr/sbin/service
```

### Debian
```
root@654afab76976:/# grep PRETTY_NAME /etc/os-release && ls -l /usr/sbin/service
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
-rwxr-xr-x. 1 root root 9097 Dec 14  2020 /usr/sbin/service
```

### Fedora
The only one whoes container image does not supply `service` in the box. It is supplied by package `initscripts-service` and that of course is a dependency of package `audit`. 

```
[root@f369ad18d075 /]# grep PRETTY_NAME /etc/os-release && ls -l /usr/sbin/service
PRETTY_NAME="Fedora Linux 37 (Container Image)"
ls: cannot access '/usr/sbin/service': No such file or directory
[root@f369ad18d075 /]# dnf provides '/usr/sbin/service'
Last metadata expiration check: 0:04:26 ago on Tue Jan 10 09:38:50 2023.
initscripts-service-10.17-1.fc37.noarch : Support for service command
Repo        : fedora
Matched from:
Filename    : /usr/sbin/service

[root@f369ad18d075 /]# dnf repoquery --requires audit | grep initscripts-service
Last metadata expiration check: 0:04:32 ago on Tue Jan 10 09:38:50 2023.
initscripts-service
```

### OpenSUSE
```
44cf0a704dd4:/ # grep PRETTY_NAME /etc/os-release && ls -l /usr/sbin/service
PRETTY_NAME="openSUSE Leap 15.4"
-rwxr-xr-x. 1 root root 5400 Oct  4 15:42 /usr/sbin/service
```

### Ubuntu
```
root@996ec2a50a4b:/# grep PRETTY_NAME /etc/os-release && ls -l /usr/sbin/service
PRETTY_NAME="Ubuntu 22.04.1 LTS"
-rwxr-xr-x. 1 root root 9097 Feb 15  2022 /usr/sbin/service
```
