### PR TITLE
Tell Linguist to treat .yml as code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Linguist: treat YAML as code instead of data
+*.yml linguist-detectable=true


### PR DESCRIPTION
---
name: Pull request
about: Make Github's language detection bar reflect project contents

---

**Describe the change**
The YAML in Ansible roles and playbooks should be detected as code by the language bar. Currently it displays the project consists of "100% Jinja2". This change tells Github's language detection (Linguist) to view YAML as code instead of configuration data. In effect: make the language bar reflect the content of the project.

**Testing**
This change will only be visible when merged to `master`. It works for other project I have applied this to. For example: https://github.com/ipr-cnrs/nftables/pull/37